### PR TITLE
Manage empty contact name

### DIFF
--- a/skynet-iads-source/skynet-iads-abstract-dcs-object-wrapper.lua
+++ b/skynet-iads-source/skynet-iads-abstract-dcs-object-wrapper.lua
@@ -18,7 +18,10 @@ end
 function SkynetIADSAbstractDCSObjectWrapper:setDCSRepresentation(representation)
 	self.dcsRepresentation = representation
 	if self.dcsRepresentation then
-		self.dcsName = self:getDCSRepresentation():getName()
+		self.dcsName = self.dcsRepresentation:getName() -- FG 11/05/2023 - baleBaron hotfix issue 81
+		if (self.dcsName == nil or string.len(self.dcsName) == 0) and self.dcsRepresentation.id_ then
+			self.dcsName = self.dcsRepresentation.id_
+		end
 	end
 end
 


### PR DESCRIPTION
baleBaron proposed fix for issue #81 at Walder's

> Since version 2.8.3.37556 of DCS, HARMs or other air weapons are not tracked correctly by the IADS.
> 
> After SkynetIADS.evaluateContacts(self) is run, only a single HARM or other air weapon is kept in the track file.
> contact:getName() returns nothing, or a blank name, so when merging contacts all but the first one is rejected.
> 
> If I do a dirty workaround like this in skynet-iads.lua on line 494 it works as expected again
> if iadsContact:getDCSRepresentation().id_ == contact:getDCSRepresentation().id_ then
> 
> I am sure someone can come up with a cleaner fix than this. :)